### PR TITLE
fix: removes lodash dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "license": "MIT",
   "dependencies": {
     "inquirer": "^6.3.1",
-    "lodash": "^4.17.11",
     "log-symbols": "^2.2.0",
     "meow": "^5.0.0",
     "ora": "^3.4.0",

--- a/questions.js
+++ b/questions.js
@@ -1,5 +1,4 @@
 const inquirer = require('inquirer')
-const _ = require('lodash')
 
 exports.askResolution = async function(formats) {
 	const answers = await inquirer.prompt([
@@ -7,7 +6,7 @@ exports.askResolution = async function(formats) {
 			type: 'list',
 			name: 'q',
 			message: 'Select resolution:',
-			choices: _.uniq(formats.map(f => f.resolution))
+			choices: [...new Set(formats.map(f => f.resolution))]
 		}
 	])
 	return answers.q


### PR DESCRIPTION
What the title says. I investigated and saw `formats.resolution` returns a string so we can safely use ES6 syntax `[...new Set()]` to remove any duplicates. Tested locally, working as expected 👍 